### PR TITLE
Fix compiler warning

### DIFF
--- a/apple-ib-als.c
+++ b/apple-ib-als.c
@@ -491,7 +491,7 @@ static int appleals_config_iio(struct appleals_device *als_dev)
 	iio_trig = devm_iio_trigger_alloc(parent, "%s-dev%d", iio_dev->name,
 					  iio_dev->id);
 	#else
-	iio_trig = devm_iio_trigger_alloc(parent, "%s-dev%d", 
+	iio_trig = devm_iio_trigger_alloc(parent, "%s-dev", 
 					  iio_dev->name);
 	#endif
 	if (!iio_trig)


### PR DESCRIPTION
```bash
aditya@MacBook:~/apple-ib-drv$ make
make -C /lib/modules/5.19.12-t2/build M=/home/aditya/apple-ib-drv modules
make[1]: Entering directory '/usr/src/linux-headers-5.19.12-t2'
  CC [M]  /home/aditya/apple-ib-drv/apple-ibridge.o
  CC [M]  /home/aditya/apple-ib-drv/apple-ib-tb.o
  CC [M]  /home/aditya/apple-ib-drv/apple-ib-als.o
/home/aditya/apple-ib-drv/apple-ib-als.c: In function ‘appleals_config_iio’:
/home/aditya/apple-ib-drv/apple-ib-als.c:494:59: warning: format ‘%d’ expects a matching ‘int’ argument [-Wformat=]
  494 |         iio_trig = devm_iio_trigger_alloc(parent, "%s-dev%d",
      |                                                          ~^
      |                                                           |
      |                                                           int
  MODPOST /home/aditya/apple-ib-drv/Module.symvers
  CC [M]  /home/aditya/apple-ib-drv/apple-ib-als.mod.o
  LD [M]  /home/aditya/apple-ib-drv/apple-ib-als.ko
  BTF [M] /home/aditya/apple-ib-drv/apple-ib-als.ko
Skipping BTF generation for /home/aditya/apple-ib-drv/apple-ib-als.ko due to unavailability of vmlinux
  CC [M]  /home/aditya/apple-ib-drv/apple-ib-tb.mod.o
  LD [M]  /home/aditya/apple-ib-drv/apple-ib-tb.ko
  BTF [M] /home/aditya/apple-ib-drv/apple-ib-tb.ko
Skipping BTF generation for /home/aditya/apple-ib-drv/apple-ib-tb.ko due to unavailability of vmlinux
  CC [M]  /home/aditya/apple-ib-drv/apple-ibridge.mod.o
  LD [M]  /home/aditya/apple-ib-drv/apple-ibridge.ko
  BTF [M] /home/aditya/apple-ib-drv/apple-ibridge.ko
Skipping BTF generation for /home/aditya/apple-ib-drv/apple-ibridge.ko due to unavailability of vmlinux
make[1]: Leaving directory '/usr/src/linux-headers-5.19.12-t2'
```

I was getting this compiler warning